### PR TITLE
🔧 Init config for web3 delay

### DIFF
--- a/ad_source/serializers.py
+++ b/ad_source/serializers.py
@@ -1,6 +1,7 @@
 import logging
 
 import requests.exceptions
+from django.conf import settings
 from djmoney.contrib.django_rest_framework import MoneyField
 from djmoney.contrib.exchange.models import Rate
 from rest_auth.serializers import UserDetailsSerializer
@@ -100,7 +101,9 @@ class TaskSerializer(serializers.HyperlinkedModelSerializer):
         if task.initial_tx_hash:
             tasks.update_task_is_active_balance.delay(task_id=task.id, wait_for_tx=str(task.initial_tx_hash))
         else:
-            tasks.update_task_is_active_balance.delay(task_id=task.id, should_be_active=True, retry=10)
+            tasks.update_task_is_active_balance.delay(
+                task_id=task.id, should_be_active=True, retry=settings.WEB3_RETRY
+            )
         tasks.create_task_screenshot.delay(task.id)
         return task
 

--- a/ad_source/tasks.py
+++ b/ad_source/tasks.py
@@ -14,8 +14,6 @@ from . import models, web3_providers
 
 logger = logging.getLogger(__name__)
 
-RETRY_COUNTDOWN = 20 * 1  # 20 seconds
-
 
 async def async_create_task_screenshot(task_id: int):
     task: models.Task = await sync_to_async(models.Task.objects.get)(id=task_id)
@@ -63,7 +61,7 @@ def update_task_is_active_balance(
     if should_be_active is not None and should_be_active != is_active and retry > 0:
         self.retry(
             kwargs={'task_id': task_id, 'should_be_active': should_be_active, 'retry': retry - 1},
-            countdown=RETRY_COUNTDOWN, max_retries=10
+            countdown=settings.WEB3_RETRY_COUNTDOWN, max_retries=settings.WEB3_RETRY_COUNTDOWN
         )
 
     task.is_active_web3 = is_active

--- a/ad_source/tests/view_sets/test_task.py
+++ b/ad_source/tests/view_sets/test_task.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import responses
+from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -120,7 +121,7 @@ class TestTaskView(mixins.DataTestMixin, APITestCase):
                 self.assertEqual(data['website_link'], 'http://does_not_exist.com/')
                 self.assertEqual(data['id'], 4)
                 self.assertEqual(data['uuid'], 'd8f01220-4c85-4b35-a3e2-9ff33858a6e7')
-                mock_update_task.assert_called_once_with(task_id=4, should_be_active=True, retry=10)
+                mock_update_task.assert_called_once_with(task_id=4, should_be_active=True, retry=settings.WEB3_RETRY)
                 mock_screenshot_task.assert_called_once_with(4)
 
     @responses.activate

--- a/ad_source/tests/view_sets/test_task_dashboard.py
+++ b/ad_source/tests/view_sets/test_task_dashboard.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import responses
+from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -73,4 +74,6 @@ class TestTaskDashboardView(mixins.DataTestMixin, APITestCase):
             data = response.json()
             self.assertEqual(response.status_code, status.HTTP_200_OK, data)
             self.assertEqual(data['website_link'], 'http://example.com')
-            mock_update_task.assert_called_once_with(task_id=task.id, should_be_active=False, retry=10)
+            mock_update_task.assert_called_once_with(
+                task_id=task.id, should_be_active=False, retry=settings.WEB3_RETRY
+            )

--- a/ad_source/view_sets.py
+++ b/ad_source/view_sets.py
@@ -116,7 +116,9 @@ class TaskDashboardViewSet(viewsets.ModelViewSet):
     def withdraw(self, request, *args, **kwargs):
         instance: models.Task = self.get_object()
         self.check_object_permissions(request, instance)
-        tasks.update_task_is_active_balance.delay(task_id=instance.id, should_be_active=False, retry=10)
+        tasks.update_task_is_active_balance.delay(
+            task_id=instance.id, should_be_active=False, retry=settings.WEB3_RETRY
+        )
         return super(TaskDashboardViewSet, self).retrieve(request, *args, **kwargs)
 
 

--- a/crowdclick/settings/__init__.py
+++ b/crowdclick/settings/__init__.py
@@ -39,6 +39,9 @@ env = environ.Env(
         'mumbai': Web3Config()  # dataclass defaults
         # 'goerli', ...
     }),
+    # Task `update_task_is_active_balance` will run up-to 30 times with 30sec delay (15 minutes) by default
+    WEB3_RETRY_COUNTDOWN=(int, 30),
+    WEB3_RETRY=(int, 30),
     ETH2USD_URL=(str, 'https://min-api.cryptocompare.com/data/pricemulti?fsyms={from_symbol}&tsyms={to_symbol}'),
     CRYPTOCOMPARE_URL=(str, 'https://min-api.cryptocompare.com/data/pricemulti?tsyms={symbols}&fsyms={base_currency}'),
     ETH2USD_CACHE_KEY=(str, 'ETH-PRICES'),

--- a/crowdclick/settings/crowdclick.py
+++ b/crowdclick/settings/crowdclick.py
@@ -14,3 +14,6 @@ LOGIN_REDIRECT_URL = '/'
 WEB3_CONFIG = {
     key: Web3Config(value) for key, value in env.dict('WEB3_CONFIG').items()
 }
+
+WEB3_RETRY_COUNTDOWN = env.int('WEB3_RETRY_COUNTDOWN')
+WEB3_RETRY = env.int('WEB3_RETRY')


### PR DESCRIPTION
This is to make `update_task_is_active_balance` configurable for `retry` and `delay`. Default values have been changed to `retry=30` & `delay=30`.
The task will run up to 15 minutes.