### PR TITLE
🐛 Fix wait_for_tx to be bytes FIXES #CROWDCLICK-CELERY-17

### DIFF
--- a/ad_source/serializers.py
+++ b/ad_source/serializers.py
@@ -131,7 +131,7 @@ class TaskSerializer(serializers.HyperlinkedModelSerializer):
                     is_correct=option.get('is_correct', False)
                 )
         if task.initial_tx_hash:
-            tasks.update_task_is_active_balance.delay(task_id=task.id, wait_for_tx=str(task.initial_tx_hash))
+            tasks.update_task_is_active_balance.delay(task_id=task.id, wait_for_tx=str.encode(task.initial_tx_hash))
         else:
             tasks.update_task_is_active_balance.delay(
                 task_id=task.id, should_be_active=True,

--- a/ad_source/tasks.py
+++ b/ad_source/tasks.py
@@ -40,7 +40,7 @@ async def async_create_task_screenshot(task_id: int):
 def update_task_is_active_balance(
         self,
         task_id: int,
-        wait_for_tx: str = '',
+        wait_for_tx: bytes = b'',
         should_be_active: bool = None,
 ) -> dict:
     """

--- a/ad_source/tests/view_sets/test_task.py
+++ b/ad_source/tests/view_sets/test_task.py
@@ -102,7 +102,7 @@ class TestTaskView(mixins.DataTestMixin, APITestCase):
                 self.assertEqual(data['website_link'], 'http://does_not_exist.com/')
                 self.assertEqual(data['id'], 4)
                 self.assertEqual(data['uuid'], 'd8f01220-4c85-4b35-a3e2-9ff33858a6e7')
-                mock_update_task.assert_called_once_with(task_id=4, wait_for_tx='0xdeadc0dedeadc0de')
+                mock_update_task.assert_called_once_with(task_id=4, wait_for_tx=b'0xdeadc0dedeadc0de')
                 mock_screenshot_task.assert_called_once_with(4)
 
     @responses.activate
@@ -138,7 +138,7 @@ class TestTaskView(mixins.DataTestMixin, APITestCase):
                 self.assertEqual(data['website_link'], 'http://does_not_exist.com/')
                 self.assertEqual(data['id'], 4)
                 self.assertEqual(data['uuid'], 'd8f01220-4c85-4b35-a3e2-9ff33858a6e7')
-                mock_update_task.assert_called_once_with(task_id=4, wait_for_tx='0xdeadc0dedeadc0de')
+                mock_update_task.assert_called_once_with(task_id=4, wait_for_tx=b'0xdeadc0dedeadc0de')
                 mock_screenshot_task.assert_called_once_with(4)
 
     @responses.activate
@@ -154,7 +154,7 @@ class TestTaskView(mixins.DataTestMixin, APITestCase):
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn('uuid', response.json())
 
-                mock_task.assert_called_once_with(task_id=4, wait_for_tx='0xdeadc0dedeadc0de')
+                mock_task.assert_called_once_with(task_id=4, wait_for_tx=b'0xdeadc0dedeadc0de')
                 mock_screenshot_task.assert_called_once_with(4)
 
     def test_create_task_admin_with_connection_error(self):
@@ -175,7 +175,7 @@ class TestTaskView(mixins.DataTestMixin, APITestCase):
                 data = response.json()
                 self.assertEqual(response.status_code, 201)
                 self.assertEqual('Website has strict X-Frame-Options: deny', data['warning_message'])
-                mock_task.assert_called_once_with(task_id=4, wait_for_tx='0xdeadc0dedeadc0de')
+                mock_task.assert_called_once_with(task_id=4, wait_for_tx=b'0xdeadc0dedeadc0de')
                 mock_screenshot_task.assert_called_once_with(4)
 
     def test_get_task_detail_anon(self):


### PR DESCRIPTION
During handling a `Timeout` error in `wait_for_transaction_receipt`, web3 library raises `TimeExhausted` with formatting `wait_for_tx` as hex. Being that a string raises TypeError.

Fixes `#CROWDCLICK-CELERY-17`